### PR TITLE
Support looking for Pods-acknowledgements.plist in old and new location.

### DIFF
--- a/lib/acknowledgements/resources.rb
+++ b/lib/acknowledgements/resources.rb
@@ -19,6 +19,7 @@ class Motion::Project::App
       # Now the app is built, but not codesigned yet.
 
       destination = File.join(config.app_bundle(platform), 'Settings.bundle/Acknowledgements.plist')
+      pods_path = 'vendor/Pods/Pods-acknowledgements.plist'
       pods_alt_path = 'vendor/Pods/Target Support Files/Pods/Pods-acknowledgements.plist'
 
       if File.exist? pods_path


### PR DESCRIPTION
Looks like newer version of CocoaPods place the plist file on a different location.
This will add support for copying the file from any of the two.
